### PR TITLE
Switched to subprocess-based installer

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,53 +1,43 @@
 #!/usr/bin/env python
 """
-Author: Ariel Anders
+Author: Arpan Rau
 Install packages for dynamics class using conda
 """
-
-try:
-    import conda.cli
-except:
-    print """
-    Cannot install packages without miniconda
-    Install miniconda from https://conda.io/miniconda.html
-    """
-    raise SystemExit
+import subprocess
 
 packages = """\
--c anaconda numpy
--c anaconda scipy 
--c anaconda matplotlib 
--c anaconda jupyter 
+numpy
+scipy 
+matplotlib 
+jupyter 
 -c https://conda.anaconda.org/kne pybox2d
--c cogsci pygame
+-c tlatorre pygame
 """
 
 pkgs = packages.strip().split("\n")
 
+Failed = False #keep track if we've failed
+
 for pkg in pkgs:
 
     try:
-        cmd = "conda install -y %s" % pkg
-        cmd = cmd.strip().split(" ")
+        cmd = "conda install -y "+pkg
+        
         print "attempting to install %s " % pkg
-        conda.cli.main(*cmd)
-    except:
+        retcode = subprocess.call(cmd,shell = True)
+
+        if retcode == 1:
+        	Failed = True
+        	print "Warning could not install %s " % pkg
+
+    except OSError:
         print "Warning could not install %s " % pkg
+        Failed = True
     
-success = 0
 
-for pkg in pkgs:
-    name = pkg.strip().split(" ")[-1]
-    if name == "pybox2d":
-        name = "Box2D"
-    cmd = "import %s " % name
-    try:
-        exec(cmd)
-        success +=1
-    except:
-        print "Import of package %s failed! "% name
-
-if success == len(pkgs):
-    print "Success: Done installing packages for dynamics!"
+if Failed ==True:
+	print "Could not install all packages! Go back and manually install failed packages."
+	print "YOUR ENVIORNMENT IS NOT SET UP. DO NOT PROCEED."
 else:
-    print "Warning could not install all packages"
+	print "All packages installed!"
+

--- a/install.py
+++ b/install.py
@@ -1,43 +1,53 @@
 #!/usr/bin/env python
 """
-Author: Arpan Rau
+Author: Ariel Anders
 Install packages for dynamics class using conda
 """
-import subprocess
+
+try:
+    import conda.cli
+except:
+    print """
+    Cannot install packages without miniconda
+    Install miniconda from https://conda.io/miniconda.html
+    """
+    raise SystemExit
 
 packages = """\
-numpy
-scipy 
-matplotlib 
-jupyter 
+-c anaconda numpy
+-c anaconda scipy 
+-c anaconda matplotlib 
+-c anaconda jupyter 
 -c https://conda.anaconda.org/kne pybox2d
--c tlatorre pygame
+-c cogsci pygame
 """
 
 pkgs = packages.strip().split("\n")
 
-Failed = False #keep track if we've failed
-
 for pkg in pkgs:
 
     try:
-        cmd = "conda install -y "+pkg
-        
+        cmd = "conda install -y %s" % pkg
+        cmd = cmd.strip().split(" ")
         print "attempting to install %s " % pkg
-        retcode = subprocess.call(cmd,shell = True)
-
-        if retcode == 1:
-        	Failed = True
-        	print "Warning could not install %s " % pkg
-
-    except OSError:
+        conda.cli.main(*cmd)
+    except:
         print "Warning could not install %s " % pkg
-        Failed = True
     
+success = 0
 
-if Failed ==True:
-	print "Could not install all packages! Go back and manually install failed packages."
-	print "YOUR ENVIORNMENT IS NOT SET UP. DO NOT PROCEED."
+for pkg in pkgs:
+    name = pkg.strip().split(" ")[-1]
+    if name == "pybox2d":
+        name = "Box2D"
+    cmd = "import %s " % name
+    try:
+        exec(cmd)
+        success +=1
+    except:
+        print "Import of package %s failed! "% name
+
+if success == len(pkgs):
+    print "Success: Done installing packages for dynamics!"
 else:
-	print "All packages installed!"
-
+    print "Warning could not install all packages"

--- a/install_nonroot.py
+++ b/install_nonroot.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""
+Author: Arpan Rau
+Install packages for dynamics class using conda
+"""
+import subprocess
+
+packages = """\
+numpy
+scipy 
+matplotlib 
+jupyter 
+-c https://conda.anaconda.org/kne pybox2d
+-c tlatorre pygame
+"""
+
+pkgs = packages.strip().split("\n")
+
+Failed = False #keep track if we've failed
+
+for pkg in pkgs:
+
+    try:
+        cmd = "conda install -y "+pkg
+        
+        print "attempting to install %s " % pkg
+        retcode = subprocess.call(cmd,shell = True)
+
+        if retcode == 1:
+        	Failed = True
+        	print "Warning could not install %s " % pkg
+
+    except OSError:
+        print "Warning could not install %s " % pkg
+        Failed = True
+    
+
+if Failed ==True:
+	print "Could not install all packages! Go back and manually install failed packages."
+	print "YOUR ENVIORNMENT IS NOT SET UP. DO NOT PROCEED."
+else:
+	print "All packages installed!"
+


### PR DESCRIPTION
Old installer would not work in non-root conda enviornments, which would make anyone trying to use multiple versions of python sad.
This one uses subprocess instead of conda.cli, which should allow it to work in any enviornment on a system with conda installed.